### PR TITLE
Simplify column types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,14 +12,10 @@ export * from './constants/colorSchemes'
 // Types
 export {
   ColumnType,
-  NumericColumnType,
-  FloatColumn,
-  IntColumn,
-  UIntColumn,
+  NumberColumn,
   TimeColumn,
   StringColumn,
   BoolColumn,
-  NumericTableColumn,
   TableColumn,
   Table,
   Scale,

--- a/src/stats/bin.test.ts
+++ b/src/stats/bin.test.ts
@@ -6,7 +6,7 @@ const TABLE: Table = {
     _value: {
       data: [70, 56, 60, 100, 76, 0, 63, 48, 79, 67],
       name: '_value',
-      type: 'int',
+      type: 'number',
     },
     _field: {
       data: [
@@ -49,10 +49,10 @@ describe('bin', () => {
     const actual = bin(TABLE, '_value', null, [], 5, 'stacked')
     const expected = {
       columns: {
-        xMin: {data: [0, 20, 40, 60, 80], type: 'int', name: 'xMin'},
-        xMax: {data: [20, 40, 60, 80, 100], type: 'int', name: 'xMax'},
-        yMin: {data: [0, 0, 0, 0, 0], type: 'int', name: 'yMin'},
-        yMax: {data: [1, 0, 2, 6, 1], type: 'int', name: 'yMax'},
+        xMin: {data: [0, 20, 40, 60, 80], type: 'number', name: 'xMin'},
+        xMax: {data: [20, 40, 60, 80, 100], type: 'number', name: 'xMax'},
+        yMin: {data: [0, 0, 0, 0, 0], type: 'number', name: 'yMin'},
+        yMax: {data: [1, 0, 2, 6, 1], type: 'number', name: 'yMax'},
       },
       length: 5,
     }
@@ -66,16 +66,24 @@ describe('bin', () => {
     const expected = {
       xMin: {
         data: [0, 20, 40, 60, 80, 0, 20, 40, 60, 80],
-        type: 'int',
+        type: 'number',
         name: 'xMin',
       },
       xMax: {
         data: [20, 40, 60, 80, 100, 20, 40, 60, 80, 100],
-        type: 'int',
+        type: 'number',
         name: 'xMax',
       },
-      yMin: {data: [0, 0, 0, 0, 0, 0, 0, 1, 3, 1], type: 'int', name: 'yMin'},
-      yMax: {data: [0, 0, 1, 3, 1, 1, 0, 2, 6, 1], type: 'int', name: 'yMax'},
+      yMin: {
+        data: [0, 0, 0, 0, 0, 0, 0, 1, 3, 1],
+        type: 'number',
+        name: 'yMin',
+      },
+      yMax: {
+        data: [0, 0, 1, 3, 1, 1, 0, 2, 6, 1],
+        type: 'number',
+        name: 'yMax',
+      },
       _field: {
         data: [
           'usage_guest',
@@ -103,16 +111,24 @@ describe('bin', () => {
     const expected = {
       xMin: {
         data: [0, 20, 40, 60, 80, 0, 20, 40, 60, 80],
-        type: 'int',
+        type: 'number',
         name: 'xMin',
       },
       xMax: {
         data: [20, 40, 60, 80, 100, 20, 40, 60, 80, 100],
-        type: 'int',
+        type: 'number',
         name: 'xMax',
       },
-      yMin: {data: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], type: 'int', name: 'yMin'},
-      yMax: {data: [0, 0, 1, 3, 1, 1, 0, 1, 3, 0], type: 'int', name: 'yMax'},
+      yMin: {
+        data: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        type: 'number',
+        name: 'yMin',
+      },
+      yMax: {
+        data: [0, 0, 1, 3, 1, 1, 0, 1, 3, 0],
+        type: 'number',
+        name: 'yMax',
+      },
       _field: {
         data: [
           'usage_guest',
@@ -140,16 +156,24 @@ describe('bin', () => {
     const expected = {
       xMin: {
         data: [-200, -160, -120, -80, -40, 0, 40, 80, 120, 160],
-        type: 'int',
+        type: 'number',
         name: 'xMin',
       },
       xMax: {
         data: [-160, -120, -80, -40, 0, 40, 80, 120, 160, 200],
-        type: 'int',
+        type: 'number',
         name: 'xMax',
       },
-      yMin: {data: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], type: 'int', name: 'yMin'},
-      yMax: {data: [0, 0, 0, 0, 0, 1, 8, 1, 0, 0], type: 'int', name: 'yMax'},
+      yMin: {
+        data: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        type: 'number',
+        name: 'yMin',
+      },
+      yMax: {
+        data: [0, 0, 0, 0, 0, 1, 8, 1, 0, 0],
+        type: 'number',
+        name: 'yMax',
+      },
     }
 
     expect(actual).toEqual(expected)
@@ -159,10 +183,10 @@ describe('bin', () => {
     const actual = bin(TABLE, '_value', [50, 80], [], 3, 'stacked').columns
 
     const expected = {
-      xMin: {data: [50, 60, 70], type: 'int', name: 'xMin'},
-      xMax: {data: [60, 70, 80], type: 'int', name: 'xMax'},
-      yMin: {data: [0, 0, 0], type: 'int', name: 'yMin'},
-      yMax: {data: [1, 3, 3], type: 'int', name: 'yMax'},
+      xMin: {data: [50, 60, 70], type: 'number', name: 'xMin'},
+      xMax: {data: [60, 70, 80], type: 'number', name: 'xMax'},
+      yMin: {data: [0, 0, 0], type: 'number', name: 'yMin'},
+      yMax: {data: [1, 3, 3], type: 'number', name: 'yMax'},
     }
 
     expect(actual).toEqual(expected)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,24 +1,10 @@
 import {SymbolType} from 'd3-shape'
 
-export type ColumnType = 'int' | 'uint' | 'float' | 'string' | 'time' | 'bool'
+export type ColumnType = 'number' | 'string' | 'time' | 'bool'
 
-export type NumericColumnType = 'int' | 'uint' | 'float' | 'time'
-
-export interface FloatColumn {
+export interface NumberColumn {
   data: number[]
-  type: 'float'
-  name: string
-}
-
-export interface IntColumn {
-  data: number[]
-  type: 'int'
-  name: string
-}
-
-export interface UIntColumn {
-  data: number[]
-  type: 'uint'
+  type: 'number'
   name: string
 }
 
@@ -40,19 +26,7 @@ export interface BoolColumn {
   name: string
 }
 
-export type NumericTableColumn =
-  | FloatColumn
-  | IntColumn
-  | UIntColumn
-  | TimeColumn
-
-export type TableColumn =
-  | FloatColumn
-  | IntColumn
-  | UIntColumn
-  | TimeColumn
-  | StringColumn
-  | BoolColumn
+export type TableColumn = NumberColumn | TimeColumn | StringColumn | BoolColumn
 
 export interface Table {
   length: number
@@ -131,10 +105,10 @@ export interface LineScales {
 
 export interface HistogramTable extends Table {
   columns: {
-    xMin: NumericTableColumn
-    xMax: NumericTableColumn
-    yMin: IntColumn
-    yMax: IntColumn
+    xMin: NumberColumn | TimeColumn
+    xMax: NumberColumn | TimeColumn
+    yMin: NumberColumn
+    yMax: NumberColumn
     [fillColumn: string]: TableColumn
   }
   length: number
@@ -142,11 +116,11 @@ export interface HistogramTable extends Table {
 
 export interface HeatmapTable extends Table {
   columns: {
-    xMin: NumericTableColumn
-    xMax: NumericTableColumn
-    yMin: NumericTableColumn
-    yMax: NumericTableColumn
-    count: IntColumn
+    xMin: NumberColumn | TimeColumn
+    xMax: NumberColumn | TimeColumn
+    yMin: NumberColumn | TimeColumn
+    yMax: NumberColumn | TimeColumn
+    count: NumberColumn
   }
   length: number
 }

--- a/src/utils/appendGroupCol.ts
+++ b/src/utils/appendGroupCol.ts
@@ -16,7 +16,7 @@ export const appendGroupCol = <T extends Table>(
     ...table,
     columns: {
       ...table.columns,
-      [GROUP_COL_KEY]: {data, type: 'string'},
+      [GROUP_COL_KEY]: {data, type: 'string', name: GROUP_COL_KEY},
     },
   }
 }

--- a/src/utils/fluxToTable.test.ts
+++ b/src/utils/fluxToTable.test.ts
@@ -41,8 +41,8 @@ describe('fluxToTable', () => {
             type: 'time',
             data: [1549064313000, 1549064323000, 1549064313000, 1549064323000],
           },
-          '_value (float)': {
-            type: 'float',
+          '_value (number)': {
+            type: 'number',
             name: '_value',
             data: [10, 20],
           },
@@ -73,7 +73,7 @@ describe('fluxToTable', () => {
           },
           table: {
             name: 'table',
-            type: 'int',
+            type: 'number',
             data: [0, 1, 2, 3],
           },
         },
@@ -86,7 +86,7 @@ describe('fluxToTable', () => {
         '_measurement',
         'cpu',
         'host',
-        '_value (float)',
+        '_value (number)',
         '_value (string)',
       ]),
     }

--- a/src/utils/fluxToTable.ts
+++ b/src/utils/fluxToTable.ts
@@ -1,7 +1,6 @@
 import {csvParse, csvParseRows} from 'd3-dsv'
 
 import {Table, ColumnType, TableColumn} from '../types'
-import {isNumeric} from './isNumeric'
 import {assert} from './assert'
 
 interface FluxToTableResult {
@@ -36,7 +35,7 @@ interface FluxToTableResult {
 
       column_a | column_b (string) | column_b (float) | column_c | column_d  <-- key
       column_a | column_b          | column_b         | column_c | column_d  <-- name
-      int      | string            | float            | int      | bool      <-- type
+      number   | string            | number           | number   | bool      <-- type
       ---------------------------------------------------------------------
              1 |               "g" |             1.0  |       34 | 
              2 |               "f" |             2.0  |       58 |
@@ -55,7 +54,7 @@ interface FluxToTableResult {
   The `Table` stores a `key` for each column which is seperate from the column
   `name`. If multiple Flux tables have the same column but with different
   types, they will be distinguished by different keys in the resulting `Table`;
-  otherwise the `key` and `value` for each column in the result table will be
+  otherwise the `key` and `name` for each column in the result table will be
   identical.
 
   [0]: https://github.com/influxdata/flux/blob/master/docs/SPEC.md#csv
@@ -185,9 +184,9 @@ const extractTableText = (chunk: string): string => {
 
 const TO_COLUMN_TYPE: {[fluxDatatype: string]: ColumnType} = {
   boolean: 'bool',
-  unsignedLong: 'uint',
-  long: 'int',
-  double: 'float',
+  unsignedLong: 'number',
+  long: 'number',
+  double: 'number',
   string: 'string',
   'dateTime:RFC3339': 'time',
 }
@@ -229,7 +228,7 @@ const parseValue = (value: string | undefined, columnType: ColumnType): any => {
     return Date.parse(value)
   }
 
-  if (isNumeric(columnType)) {
+  if (columnType === 'number') {
     return Number(value)
   }
 

--- a/src/utils/getNumericColumn.ts
+++ b/src/utils/getNumericColumn.ts
@@ -1,11 +1,11 @@
 import {assert} from './assert'
 import {isNumeric} from './isNumeric'
-import {Table, NumericTableColumn} from '../types'
+import {Table, NumberColumn, TimeColumn} from '../types'
 
 export const getNumericColumn = (
   table: Table,
   key: string
-): NumericTableColumn => {
+): NumberColumn | TimeColumn => {
   const col = table.columns[key]
 
   assert(
@@ -15,5 +15,5 @@ export const getNumericColumn = (
     isNumeric(col.type)
   )
 
-  return col as NumericTableColumn
+  return col as NumberColumn | TimeColumn
 }

--- a/src/utils/isNumeric.ts
+++ b/src/utils/isNumeric.ts
@@ -1,6 +1,4 @@
 import {ColumnType} from '../types'
 
-const NUMERIC_TYPES = new Set(['uint', 'int', 'float', 'time'])
-
 export const isNumeric = (columnType: ColumnType): boolean =>
-  NUMERIC_TYPES.has(columnType)
+  columnType === 'number' || columnType === 'time'

--- a/src/utils/table.test.ts
+++ b/src/utils/table.test.ts
@@ -6,12 +6,12 @@ test('filterTable', () => {
     columns: {
       a: {
         name: 'a',
-        type: 'int',
+        type: 'number',
         data: [11, 15, 20, 4, 2],
       },
       b: {
         name: 'b',
-        type: 'int',
+        type: 'number',
         data: [1, 2, 3, 1, 9],
       },
     },
@@ -24,12 +24,12 @@ test('filterTable', () => {
     columns: {
       a: {
         name: 'a',
-        type: 'int',
+        type: 'number',
         data: [15, 20, 2],
       },
       b: {
         name: 'b',
-        type: 'int',
+        type: 'number',
         data: [2, 3, 9],
       },
     },

--- a/stories/data.ts
+++ b/stories/data.ts
@@ -2011,7 +2011,7 @@ export const TABLE: Table = {
         1.2012012012012012,
         1.098901098901099,
       ],
-      type: 'float',
+      type: 'number',
       name: '_value',
     },
     cpu: {


### PR DESCRIPTION
Previously we had three different types of possible number columns: `uint`, `int`, and `float`, though the corresponding `data` for each type of column was always of type `number[]`. The motivation for the multiple number types was to be able to efficiently store numeric data as typed arrays, and to provide different default formatting based on the type of number. 

We haven't leveraged these opportunities yet, and it's not clear that we ever will. In the meantime, the multiple number types just add complexity. 