### PR TITLE
Fix clipping issue in line layers

### DIFF
--- a/src/components/Axes.tsx
+++ b/src/components/Axes.tsx
@@ -12,6 +12,10 @@ interface Props {
   style: CSSProperties
 }
 
+// A grid line must be at least this many pixels away from both parallel axes
+// in order to be drawn
+const GRID_LINE_MIN_DIST = 5
+
 interface DrawAxesOptions {
   canvas: HTMLCanvasElement
   innerWidth: number
@@ -64,12 +68,17 @@ export const drawAxes = ({
   for (const xTick of xTicks) {
     const x = xScale(xTick) + margins.left
 
-    context.strokeStyle = gridColor
-    context.globalAlpha = gridOpacity
-    context.beginPath()
-    context.moveTo(x, xAxisY)
-    context.lineTo(x, margins.top)
-    context.stroke()
+    if (
+      Math.abs(x - margins.left) > GRID_LINE_MIN_DIST &&
+      Math.abs(x - (width - margins.right)) > GRID_LINE_MIN_DIST
+    ) {
+      context.strokeStyle = gridColor
+      context.globalAlpha = gridOpacity
+      context.beginPath()
+      context.moveTo(x, xAxisY)
+      context.lineTo(x, margins.top)
+      context.stroke()
+    }
 
     context.globalAlpha = 1
     context.fillStyle = tickFontColor
@@ -84,12 +93,17 @@ export const drawAxes = ({
   for (const yTick of yTicks) {
     const y = yScale(yTick) + margins.top
 
-    context.strokeStyle = gridColor
-    context.globalAlpha = gridOpacity
-    context.beginPath()
-    context.moveTo(margins.left, y)
-    context.lineTo(width - margins.right, y)
-    context.stroke()
+    if (
+      Math.abs(y - margins.top) > GRID_LINE_MIN_DIST &&
+      Math.abs(y - (height - margins.bottom)) > GRID_LINE_MIN_DIST
+    ) {
+      context.strokeStyle = gridColor
+      context.globalAlpha = gridOpacity
+      context.beginPath()
+      context.moveTo(margins.left, y)
+      context.lineTo(width - margins.right, y)
+      context.stroke()
+    }
 
     context.globalAlpha = 1
     context.fillStyle = tickFontColor

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -16,6 +16,7 @@ import {NINETEEN_EIGHTY_FOUR as DEFAULT_COLOR_SCHEME} from './colorSchemes'
 export const TICK_PADDING_RIGHT = 8
 export const TICK_PADDING_TOP = 8
 export const AXIS_LABEL_PADDING_BOTTOM = 15
+export const DEFAULT_RANGE_PADDING = 0 // pixels
 
 export const GROUP_COL_KEY = '_vis_group_keys'
 export const FILL_COL_KEY = '_fill_group_keys'

--- a/src/utils/PlotEnv.test.ts
+++ b/src/utils/PlotEnv.test.ts
@@ -48,16 +48,18 @@ describe('PlotEnv', () => {
 
       plotEnv.config = config
 
-      expect(plotEnv.xScale(10)).toEqual(0)
+      const rangePadding = plotEnv['rangePadding']
+
+      expect(plotEnv.xScale(10)).toEqual(rangePadding)
       expect(plotEnv.xScale(19)).toEqual(
-        1000 - plotEnv.margins.left - plotEnv.margins.right
+        1000 - plotEnv.margins.left - plotEnv.margins.right - rangePadding * 2
       )
 
       plotEnv.config = {...config, xDomain: [10, 28]}
 
-      expect(plotEnv.xScale(10)).toEqual(0)
+      expect(plotEnv.xScale(10)).toEqual(rangePadding)
       expect(plotEnv.xScale(28)).toEqual(
-        1000 - plotEnv.margins.left - plotEnv.margins.right
+        1000 - plotEnv.margins.left - plotEnv.margins.right - rangePadding * 2
       )
     })
 

--- a/src/utils/PlotEnv.ts
+++ b/src/utils/PlotEnv.ts
@@ -10,9 +10,14 @@ import {
   TableColumn,
   ColumnType,
   HeatmapTable,
+  LineLayerConfig,
 } from '../types'
 
-import {LAYER_DEFAULTS, CONFIG_DEFAULTS} from '../constants'
+import {
+  DEFAULT_RANGE_PADDING,
+  LAYER_DEFAULTS,
+  CONFIG_DEFAULTS,
+} from '../constants'
 
 import * as transforms from '../layerTransforms'
 import {getTicks} from './getTicks'
@@ -434,16 +439,28 @@ export class PlotEnv {
     return col
   }
 
+  private get rangePadding(): number {
+    const specifiedLineWidths = this.config.layers
+      .filter(l => l.type === 'line')
+      .map(l => (l as LineLayerConfig).lineWidth)
+
+    return Math.max(DEFAULT_RANGE_PADDING, ...specifiedLineWidths)
+  }
+
   private getXScale = memoizeOne((xDomain: number[], innerWidth: number) => {
+    const {rangePadding} = this
+
     return scaleLinear()
       .domain(xDomain)
-      .range([0, innerWidth])
+      .range([rangePadding, innerWidth - rangePadding * 2])
   })
 
   private getYScale = memoizeOne((yDomain: number[], innerHeight: number) => {
+    const {rangePadding} = this
+
     return scaleLinear()
       .domain(yDomain)
-      .range([innerHeight, 0])
+      .range([innerHeight - rangePadding * 2, rangePadding])
   })
 }
 

--- a/stories/snapshotTests.stories.tsx
+++ b/stories/snapshotTests.stories.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react'
+import {storiesOf} from '@storybook/react'
+
+import {fluxToTable, Config, Plot} from '../src'
+
+storiesOf('Snapshot Tests', module).add('with multiple minimum values', () => {
+  // https://github.com/influxdata/vis/issues/51
+
+  const {table} = fluxToTable(
+    `#group,false,false,true,false,false
+#datatype,string,long,string,long,dateTime:RFC3339
+#default,_result,,,,
+,result,table,_field,_value,_time
+,,0,event,0,2019-05-01T12:00:00Z
+,,0,event,0,2019-05-02T00:00:00Z
+,,0,event,0,2019-05-02T12:00:00Z
+,,0,event,0,2019-05-03T00:00:00Z
+,,0,event,0,2019-05-03T12:00:00Z
+,,0,event,1,2019-05-04T00:00:00Z
+,,0,event,6,2019-05-04T12:00:00Z
+,,0,event,0,2019-05-05T00:00:00Z
+,,0,event,0,2019-05-05T12:00:00Z
+,,0,event,2,2019-05-06T00:00:00Z
+,,0,event,0,2019-05-06T12:00:00Z
+,,0,event,10,2019-05-07T00:00:00Z
+,,0,event,0,2019-05-07T06:00:00Z`
+  )
+
+  const config: Config = {
+    width: 600,
+    height: 400,
+    table,
+    layers: [
+      {
+        type: 'line',
+        x: '_time',
+        y: '_value',
+      },
+    ],
+  }
+
+  return <Plot config={config} />
+})


### PR DESCRIPTION
Lines in line layers were being clipped under the following conditions:

- Non-HiDPI screen
- Line layer with a `lineWidth` setting of 1
- With data containing successive minimum or maximum values

This seemed to be caused by antialiasing.

This commit adds 1 `lineWidth` of padding to the edges of the plots to avoid the issue.

Closes #51