### PR TITLE
Add new shapes to scatter repertoire

### DIFF
--- a/src/components/ScatterLayer.tsx
+++ b/src/components/ScatterLayer.tsx
@@ -6,7 +6,14 @@ import {Table, Scale, ScatterLayerConfig, NumericColumnData} from '../types'
 import {PlotEnv} from '../utils/PlotEnv'
 import {clearCanvas} from '../utils/clearCanvas'
 import {FILL, SYMBOL} from '../constants/columnKeys'
-import {drawCircle, drawSquare, drawTriangle} from '../utils/drawShapes'
+import {
+  drawCircle,
+  drawSquare,
+  drawPlus,
+  drawTriangle,
+  drawTritip,
+  drawEx,
+} from '../utils/drawShapes'
 
 type ScatterData = {
   xs: NumericColumnData
@@ -52,19 +59,25 @@ const drawPoints = ({
   for (var i = 0; i < xs.length; i++) {
     const x = xScale(xs[i])
     const y = yScale(ys[i])
-    const fillStyle = fill[i]
-    const symbolType = symbol[i]
 
+    const fillStyle = fill[i]
     context.fillStyle = fillStyle
-    context.beginPath()
+    context.strokeStyle = fillStyle
+
+    const symbolType = symbol[i]
     if (symbolType === 'circle') {
       drawCircle(context, x, y)
     } else if (symbolType === 'square') {
       drawSquare(context, x, y)
     } else if (symbolType === 'triangle') {
       drawTriangle(context, x, y)
+    } else if (symbolType === 'plus') {
+      drawPlus(context, x, y)
+    } else if (symbolType === 'tritip') {
+      drawTritip(context, x, y)
+    } else if (symbolType === 'ex') {
+      drawEx(context, x, y)
     }
-    context.fill()
   }
 }
 

--- a/src/utils/drawShapes.ts
+++ b/src/utils/drawShapes.ts
@@ -1,41 +1,112 @@
 export const drawCircle = (
   ctx: CanvasRenderingContext2D,
-  centerX: number,
-  centerY: number,
-  r?: number
+  x: number,
+  y: number,
+  radius: number = 2
 ) => {
-  const radius = r ? r : 2
-  const x = centerX - radius / 2
-  const y = centerY - radius / 2
-
-  const Zero = 0
-  const TwoPi = Math.PI * 2
-
-  ctx.arc(x, y, radius, Zero, TwoPi, true)
+  ctx.beginPath()
+  ctx.arc(x, y, radius, 0, Math.PI * 2, true)
+  ctx.fill()
 }
 
 export const drawSquare = (
   ctx: CanvasRenderingContext2D,
   centerX: number,
   centerY: number,
-  s?: number
+  size: number = 4
 ) => {
-  const size = s ? s : 6
   const x = centerX - size / 2
   const y = centerY - size / 2
 
-  ctx.fillRect(x, y, size, size)
+  ctx.lineWidth = 1
+
+  ctx.rect(x, y, size, size)
+  ctx.stroke()
 }
 
 export const drawTriangle = (
   ctx: CanvasRenderingContext2D,
-  x: number,
-  y: number,
-  s?: number
+  centerX: number,
+  centerY: number,
+  size: number = 3
 ) => {
-  const size = s ? s : 4
+  ctx.beginPath()
+  ctx.moveTo(centerX - size, centerY + size)
+  ctx.lineTo(centerX + size, centerY + size)
+  ctx.lineTo(centerX, centerY - size)
+  ctx.fill()
+}
 
-  ctx.moveTo(x - size, y + size)
-  ctx.lineTo(x + size, y + size)
-  ctx.lineTo(x, y - size)
+export const drawPlus = (
+  ctx: CanvasRenderingContext2D,
+  centerX: number,
+  centerY: number,
+  size: number = 6
+) => {
+  const mid = size / 2
+
+  ctx.lineWidth = 1
+
+  ctx.beginPath()
+  ctx.moveTo(centerX - mid, centerY)
+  ctx.lineTo(centerX + mid, centerY)
+  ctx.stroke()
+
+  ctx.beginPath()
+  ctx.moveTo(centerX, centerY - mid)
+  ctx.lineTo(centerX, centerY + mid)
+  ctx.stroke()
+}
+
+export const drawEx = (
+  ctx: CanvasRenderingContext2D,
+  centerX: number,
+  centerY: number,
+  size: number = 5
+) => {
+  const mid = size / 2
+
+  ctx.lineWidth = 1
+
+  ctx.beginPath()
+  ctx.moveTo(centerX - mid, centerY - mid)
+  ctx.lineTo(centerX + mid, centerY + mid)
+  ctx.closePath()
+  ctx.stroke()
+
+  ctx.beginPath()
+  ctx.moveTo(centerX - mid, centerY + mid)
+  ctx.lineTo(centerX + mid, centerY - mid)
+  ctx.closePath()
+  ctx.stroke()
+}
+
+export const drawTritip = (
+  ctx: CanvasRenderingContext2D,
+  centerX: number,
+  centerY: number,
+  size: number = 3
+) => {
+  const cos30 = 0.86602540378
+  const sin30 = 0.5
+
+  ctx.lineWidth = 1
+
+  ctx.beginPath()
+  ctx.moveTo(centerX, centerY)
+  ctx.lineTo(centerX + cos30 * size, centerY + sin30 * size)
+  ctx.closePath()
+  ctx.stroke()
+
+  ctx.beginPath()
+  ctx.moveTo(centerX, centerY)
+  ctx.lineTo(centerX - cos30 * size, centerY + sin30 * size)
+  ctx.closePath()
+  ctx.stroke()
+
+  ctx.beginPath()
+  ctx.moveTo(centerX, centerY)
+  ctx.lineTo(centerX, centerY - size)
+  ctx.closePath()
+  ctx.stroke()
 }

--- a/src/utils/getSymbolScale.ts
+++ b/src/utils/getSymbolScale.ts
@@ -2,13 +2,26 @@ import {scaleOrdinal} from 'd3-scale'
 import {Table, Scale} from '../types'
 import {SYMBOL} from '../constants/columnKeys'
 
-export type SymbolType = 'circle' | 'triangle' | 'square'
+export type SymbolType =
+  | 'circle'
+  | 'triangle'
+  | 'square'
+  | 'plus'
+  | 'tritip'
+  | 'ex'
 
 export const getSymbolScale = (table: Table): Scale<string, SymbolType> => {
   const symbolCol = table.getColumn(SYMBOL, 'string')
   const uniqueValues = Array.from(new Set(symbolCol))
 
-  const symbolTypes = ['circle', 'triangle', 'square'] as SymbolType[]
+  const symbolTypes: SymbolType[] = [
+    'circle',
+    'plus',
+    'triangle',
+    'tritip',
+    'square',
+    'ex',
+  ]
 
   const scale = scaleOrdinal<string, SymbolType>()
     .domain(uniqueValues)


### PR DESCRIPTION
Add tritip, hollow square, ex, and plus to scatter plot shapes
correct the placement of the circle. 