### PR TITLE
Convert getDay to getDate

### DIFF
--- a/src/utils/getTimeFormatter.ts
+++ b/src/utils/getTimeFormatter.ts
@@ -50,10 +50,10 @@ const FORMATTERS: [number, ((d: Date) => string)][] = [
   ],
   [
     1000 * 60 * 60 * 24 * 30,
-    d => `${d.getFullYear()}-${leftPad(d.getMonth() + 1)}-${leftPad(d.getDay())} ${leftPad(d.getHours())}:${leftPad(d.getMinutes())}`,
+    d => `${d.getFullYear()}-${leftPad(d.getMonth() + 1)}-${leftPad(d.getDate())} ${leftPad(d.getHours())}:${leftPad(d.getMinutes())}`,
   ],
   [
     1000 * 60 * 60 * 24 * 30,
-    d => `${d.getFullYear()}-${leftPad(d.getMonth() + 1)}-${leftPad(d.getDay())}`,
+    d => `${d.getFullYear()}-${leftPad(d.getMonth() + 1)}-${leftPad(d.getDate())}`,
   ],
 ]


### PR DESCRIPTION
Date.prototype.getDay() OBVIOUSLY returns the day of the week.
Date.prototype.getDate() returns the actual day of the month.
gah.

Closes https://github.com/influxdata/vis/issues/55