### PR TITLE
Add begin path to each square draw to improve scatter performance

### DIFF
--- a/src/utils/drawShapes.ts
+++ b/src/utils/drawShapes.ts
@@ -21,7 +21,7 @@ export const drawSquare = (
 ) => {
   const x = centerX - size / 2
   const y = centerY - size / 2
-
+  ctx.beginPath()
   ctx.rect(x, y, size, size)
   ctx.fill()
 }


### PR DESCRIPTION
I noticed scatter plot performance downgrading. 
Found this: 
https://stackoverflow.com/questions/28534715/why-does-filling-in-a-rectangle-on-a-canvas-degrade-performance-slowly
verified perf improvement in devtools.