### PR TITLE
Return null if getColumn can not find column

### DIFF
--- a/src/utils/newTable.ts
+++ b/src/utils/newTable.ts
@@ -20,20 +20,18 @@ class SimpleTable implements Table {
     return Object.keys(this.columns)
   }
 
-  getColumn(columnKey: string, columnType?: ColumnType): any[] {
+  getColumn(columnKey: string, columnType?: ColumnType): any[] | null {
     const column = this.columns[columnKey]
 
     if (!column) {
-      throw new Error('column not found')
+      return null
     }
 
     // Allow time columns to be retrieved as number columns
     const isWideningTimeType = columnType === 'number' && column.type === 'time'
 
     if (columnType && columnType !== column.type && !isWideningTimeType) {
-      throw new Error(
-        `expected ${columnType} column, found ${column.type} column instead`
-      )
+      return null
     }
 
     switch (columnType) {


### PR DESCRIPTION
Previously getColumn would throw an error if column specified did not exist or was not of type specified.
Closes https://github.com/influxdata/vis/issues/68