### PR TITLE
Fix unnecessary line layer renders

### DIFF
--- a/src/utils/PlotEnv.ts
+++ b/src/utils/PlotEnv.ts
@@ -113,20 +113,24 @@ export class PlotEnv {
     const getXScaleMemoized = this.fns.get('xScale', getLinearScale)
     const {xDomain, rangePadding, innerWidth} = this
 
-    return getXScaleMemoized(xDomain, [
+    return getXScaleMemoized(
+      xDomain[0],
+      xDomain[1],
       rangePadding,
-      innerWidth - rangePadding * 2,
-    ])
+      innerWidth - rangePadding * 2
+    )
   }
 
   public get yScale(): Scale<number, number> {
     const getYScaleMemoized = this.fns.get('yScale', getLinearScale)
     const {yDomain, rangePadding, innerHeight} = this
 
-    return getYScaleMemoized(yDomain, [
+    return getYScaleMemoized(
+      yDomain[0],
+      yDomain[1],
       innerHeight - rangePadding * 2,
-      rangePadding,
-    ])
+      rangePadding
+    )
   }
 
   public get xDomain(): number[] {

--- a/src/utils/getLinearScale.ts
+++ b/src/utils/getLinearScale.ts
@@ -3,10 +3,12 @@ import {scaleLinear} from 'd3-scale'
 import {Scale} from '../types'
 
 export const getLinearScale = (
-  domain: number[],
-  range: number[]
+  domainStart: number,
+  domainStop: number,
+  rangeStart: number,
+  rangeStop: number
 ): Scale<number, number> => {
   return scaleLinear()
-    .domain(domain)
-    .range(range)
+    .domain([domainStart, domainStop])
+    .range([rangeStart, rangeStop])
 }

--- a/src/utils/lineData.ts
+++ b/src/utils/lineData.ts
@@ -51,7 +51,7 @@ export const simplifyLineData = (
     const [simplifedXs, simplifiedYs] = simplify(
       xs.map(x => xScale(x)),
       ys.map(y => yScale(y)),
-      1
+      0.5
     )
 
     result[k] = {xs: simplifedXs, ys: simplifiedYs, fill}

--- a/src/utils/useChangedDepsLogger.ts
+++ b/src/utils/useChangedDepsLogger.ts
@@ -1,5 +1,26 @@
 import {useRef, MutableRefObject} from 'react'
 
+/*
+  This utility can be used to debug why a `useEffect` or `useMemo` hook is
+  firing.
+
+  For example, given the following hook:
+
+      useEffect(() => {
+        doTheThing()
+      }, [a, b, c])
+
+  We can place the `useChangeDepsLogger` immediately after:
+
+      useEffect(() => {
+        doTheThing()
+      }, [a, b, c])
+
+      useChangedDepsLogger({a, b, c})
+
+  If any of the dependencies `a`, `b`, or `c` changes in a render (causing the
+  effect to fire) then a message will be logged to the console.
+*/
 export const useChangedDepsLogger = deps => {
   const prevDeps: MutableRefObject<any> = useRef({})
 

--- a/src/utils/useChangedDepsLogger.ts
+++ b/src/utils/useChangedDepsLogger.ts
@@ -1,0 +1,18 @@
+import {useRef, MutableRefObject} from 'react'
+
+export const useChangedDepsLogger = deps => {
+  const prevDeps: MutableRefObject<any> = useRef({})
+
+  for (const key of Object.keys(deps)) {
+    if (deps[key] !== prevDeps.current[key]) {
+      // eslint-disable-next-line no-console
+      console.log(
+        `dependency changed: ${key}`,
+        prevDeps.current[key],
+        deps[key]
+      )
+    }
+  }
+
+  prevDeps.current = deps
+}

--- a/stories/sin.stories.tsx
+++ b/stories/sin.stories.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react'
+import {storiesOf} from '@storybook/react'
+
+import {Config, Plot} from '../src'
+import {SIN} from './sin'
+
+import {PlotContainer} from './helpers'
+
+storiesOf('Line Plot Stress Test', module).add('Line', () => {
+  const config: Config = {
+    table: SIN,
+    layers: [
+      {
+        type: 'line',
+        x: 'x',
+        y: 'y',
+        fill: ['tag'],
+      },
+    ],
+  }
+
+  return (
+    <PlotContainer>
+      <Plot config={config} />
+    </PlotContainer>
+  )
+})

--- a/stories/sin.ts
+++ b/stories/sin.ts
@@ -1,0 +1,29 @@
+import {range} from 'd3-array'
+
+import {newTable} from '../src'
+
+const size = 200000
+const tags = ['a', 'b', 'c', 'd', 'e']
+const pointsPerUnit = 1000
+
+const xs = range(0, size / pointsPerUnit, 1 / pointsPerUnit)
+
+const xCol = []
+const yCol = []
+const tagCol = []
+
+for (let i = 0; i < tags.length; i++) {
+  const tag = tags[i]
+  const phaseShift = i
+
+  for (const x of xs) {
+    xCol.push(x)
+    yCol.push(Math.sin(x + phaseShift))
+    tagCol.push(tag)
+  }
+}
+
+export const SIN = newTable(size * tags.length)
+  .addColumn('x', 'number', xCol)
+  .addColumn('y', 'number', yCol)
+  .addColumn('tag', 'string', tagCol)


### PR DESCRIPTION
The line layer was being re-rendered on every hover event, due to a bug in the memoization of the x and y scales.

Also adds a story for experimenting with large datasets. The following plot has 5 series with 200,000 points each:

![Screenshot 2019-06-05T11:07:43](https://user-images.githubusercontent.com/638955/58979145-3703b980-8782-11e9-8b74-8479a1b40cb9.png)

The size of the dataset can be changed by tweaking the parameters in `stories/sin.ts`.
